### PR TITLE
besu:25.1.0 --host-whitelist has been deprecated

### DIFF
--- a/scripts/besu/docker-compose.yaml
+++ b/scripts/besu/docker-compose.yaml
@@ -37,7 +37,7 @@ services:
     - --rpc-http-port=8545
     - --rpc-http-api=${EC_ENABLED_MODULES}
     - --rpc-http-cors-origins=*
-    - --host-whitelist=*
+    - --host-allowlist=*
     - --genesis-state-hash-cache-enabled=true
     logging:
       driver: json-file


### PR DESCRIPTION
ref: https://github.com/hyperledger/besu/releases/tag/25.1.0