### PR TITLE
optimize(erigon): refactor first/second run docker compose

### DIFF
--- a/scripts/erigon/docker-compose-second.yaml
+++ b/scripts/erigon/docker-compose-second.yaml
@@ -1,16 +1,15 @@
-version: "3.9"
 services:
   execution:
     user: "root:root"
     stop_grace_period: 30m
     container_name: gas-execution-client
     restart: unless-stopped
-    image: ${EC_IMAGE_VERSION}
+    image: ${EC_IMAGE_VERSION:-erigontech/erigon:v3.0.0-rc1}
     networks:
     - gas
     volumes:
-    - ${EC_DATA_DIR}:/var/lib/erigon
-    - ${EC_JWT_SECRET_PATH}:/tmp/jwt/jwtsecret
+    - ${EC_DATA_DIR:-./erigon-data}:/var/lib/erigon
+    - ${EC_JWT_SECRET_PATH:-/tmp/jwtsecret}:/tmp/jwt/jwtsecret
     ports:
     - "30303:30303/tcp"
     - "30303:30303/udp"
@@ -27,7 +26,7 @@ services:
     - --http.corsdomain=*
     - --http.api=web3,eth,net,engine
     - --txpool.disable
-    - --chain=${NETWORK}
+    - --chain=${NETWORK:-holesky}
     - --authrpc.addr=0.0.0.0
     - --authrpc.port=8551
     - --authrpc.vhosts=*
@@ -38,6 +37,7 @@ services:
     - --metrics.addr=0.0.0.0
     - --metrics.port=8008
     - --db.size.limit=2GB
+    - --externalcl
     logging:
       driver: json-file
       options:

--- a/scripts/erigon/docker-compose.yaml
+++ b/scripts/erigon/docker-compose.yaml
@@ -1,63 +1,25 @@
-version: "3.9"
 services:
-  execution-sync:
+  execution-init:
     user: "root:root"
-    container_name: gas-execution-client-sync
-    image: ${EC_IMAGE_VERSION}
+    container_name: gas-execution-client-init
+    image: ${EC_IMAGE_VERSION:-erigontech/erigon:v3.0.0-rc1}
     networks:
     - gas
     volumes:
-    - ${EC_DATA_DIR}:/var/lib/erigon
-    - ${EC_JWT_SECRET_PATH}:/tmp/jwt/jwtsecret
-    - ${GENESIS_PATH}:/tmp/genesis/genesis.json
+    - ${EC_DATA_DIR:-./erigon-data}:/var/lib/erigon
+    - ${EC_JWT_SECRET_PATH:-/tmp/jwtsecret}:/tmp/jwt/jwtsecret
+    - ${GENESIS_PATH:-/tmp/genesis.json}:/tmp/genesis/genesis.json
     entrypoint: erigon init --datadir=/var/lib/erigon /tmp/genesis/genesis.json
+  
+  # Extend the execution service from execution.yaml and add dependency
   execution:
-    user: "root:root"
-    stop_grace_period: 30m
-    container_name: gas-execution-client
+    extends:
+      file: docker-compose-second.yaml
+      service: execution
     depends_on:
-      execution-sync:
+      execution-init:
         condition: service_completed_successfully
-    restart: unless-stopped
-    image: ${EC_IMAGE_VERSION}
-    networks:
-    - gas
-    volumes:
-    - ${EC_DATA_DIR}:/var/lib/erigon
-    - ${EC_JWT_SECRET_PATH}:/tmp/jwt/jwtsecret
-    ports:
-    - "30303:30303/tcp"
-    - "30303:30303/udp"
-    - "8008:8008/tcp"
-    - "8545:8545"
-    - "8551:8551"
-    command:
-    - --private.api.addr=0.0.0.0:9090
-    - --nat=any
-    - --http
-    - --http.addr=0.0.0.0
-    - --http.port=8545
-    - --http.vhosts=*
-    - --http.corsdomain=*
-    - --http.api=web3,eth,net,engine
-    - --txpool.disable
-    - --chain=${NETWORK}
-    - --authrpc.addr=0.0.0.0
-    - --authrpc.port=8551
-    - --authrpc.vhosts=*
-    - --authrpc.jwtsecret=/tmp/jwt/jwtsecret
-    - --datadir=/var/lib/erigon
-    - --healthcheck
-    - --metrics
-    - --metrics.addr=0.0.0.0
-    - --metrics.port=8008
-    - --db.size.limit=2GB
-    - --externalcl
-    logging:
-      driver: json-file
-      options:
-        max-size: 10m
-        max-file: "10"
+
 networks:
   gas:
     name: gas-network


### PR DESCRIPTION
1. reuse the same execution part
2. specify default parms like chain(fix:time="2025-03-05T03:43:57Z" level=warning msg="The \"NETWORK\" variable is not set. Defaulting to a blank string." )


logs:
```
time="2025-03-05T03:51:27Z" level=warning msg="/root/benchmarks/burntpix-benchmarks/scripts/geth/docker-compose.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"


# burntpix: for erigon3 --chain parm must specfiy
gas-execution-client       | [WARN] [03-05|03:57:59.978] No snapshot hashes for chain             chain=
gas-execution-client       | [INFO] [03-05|03:57:59.979] Maximum peer count                       total=32
gas-execution-client       | [INFO] [03-05|03:57:59.979] starting HTTP APIs                       port=8545 APIs=web3,eth,net,engine
gas-execution-client       | [EROR] [03-05|03:57:59.980] catch panic                              err="runtime error: invalid memory address or nil pointer dereference" stack="[main.go:46 panic.go:785 panic.go:262 signal_unix.go:917 flags.go:1722 flags.go:1942 node.go:121 main.go:96 make_app.go:71 command.go:276 app.go:333 app.go:307 main.go:51 proc.go:272 asm_amd64.s:1700]"
gas-execution-client       | [INFO] [03-05|03:58:01.188] logging to file system                   log dir=/var/lib/erigon/logs file prefix=erigon log level=info json=false
```