### PR TITLE
fix: log entry for erigon,geth,reth  reflect accurate initialization status

### DIFF
--- a/runMemory.sh
+++ b/runMemory.sh
@@ -253,10 +253,12 @@ for size in "${SIZES[@]}"; do
 
       echo "[DEBUG] Second start sleeping for 10 seconds..."
       sleep 10
-      if [ "$client" = "erigon" ]; then
-        log_entry="Initialised chain configuration"
-        echo "[DEBUG] For Client $client,second start log_entry is $log_entry"
-      fi
+      case $client in
+      erigon) log_entry="Initialised chain configuration" ;;
+      geth) log_entry="Chain ID" ;;
+      reth) log_entry="Database opened" ;;
+      esac
+      echo "[DEBUG] For Client $client,second start log_entry is '$log_entry'"
       check_initialization_completed $client "$log_entry"
       if [ $? -ne 0 ]; then
         stop_memory_monitor

--- a/runMemory.sh
+++ b/runMemory.sh
@@ -253,6 +253,10 @@ for size in "${SIZES[@]}"; do
 
       echo "[DEBUG] Second start sleeping for 10 seconds..."
       sleep 10
+      if [ "$client" = "erigon" ]; then
+        log_entry="Initialised chain configuration"
+        echo "[DEBUG] For Client $client,second start log_entry is $log_entry"
+      fi
       check_initialization_completed $client "$log_entry"
       if [ $? -ne 0 ]; then
         stop_memory_monitor

--- a/runSpeed.sh
+++ b/runSpeed.sh
@@ -230,6 +230,10 @@ for size in "${SIZES[@]}"; do
 
       # second init
       start_time=$(($(date +%s%N) / 1000000))
+      if [ "$client" = "erigon" ]; then
+        log_entry="Initialised chain configuration"
+        echo "[DEBUG] For Client $client,second start log_entry is '$log_entry'"
+      fi
       run_setup_and_initialization $client $image $run $size $output_file_second "$log_entry" $start_time true
 
     done

--- a/runSpeed.sh
+++ b/runSpeed.sh
@@ -230,10 +230,12 @@ for size in "${SIZES[@]}"; do
 
       # second init
       start_time=$(($(date +%s%N) / 1000000))
-      if [ "$client" = "erigon" ]; then
-        log_entry="Initialised chain configuration"
-        echo "[DEBUG] For Client $client,second start log_entry is '$log_entry'"
-      fi
+      case $client in
+      erigon) log_entry="Initialised chain configuration" ;;
+      geth) log_entry="Chain ID" ;;
+      reth) log_entry="Database opened" ;;
+      esac
+      echo "[DEBUG] For Client $client,second start log_entry is '$log_entry'"
       run_setup_and_initialization $client $image $run $size $output_file_second "$log_entry" $start_time true
 
     done


### PR DESCRIPTION
When launching clients like **Erigon**, **Geth**, or **Reth** that require an initial setup process,  set up accurate **`log_entry`** to reflect the true time required to launch the client on the second startup 