### PR TITLE
fix: add a new container_clean function to preserve execution data before second startup

### DIFF
--- a/runMemory.sh
+++ b/runMemory.sh
@@ -170,6 +170,15 @@ clean_up() {
   echo "[INFO] Cleanup completed."
 }
 
+# skips deleting execution-data so data persists for second start.
+container_clean() {
+  echo "[INFO] Cleaning up containers (preserving data)..."
+  docker stop gas-execution-client gas-execution-client-sync
+  docker rm gas-execution-client gas-execution-client-sync
+  docker container prune -f
+  echo "[INFO] Container cleanup completed."
+}
+
 for size in "${SIZES[@]}"; do
 
   echo "[INFO] Calculating new size for $size"
@@ -237,7 +246,7 @@ for size in "${SIZES[@]}"; do
 
       cd "scripts/$client"
       docker compose stop
-      clean_up
+      container_clean
       cd ../..
 
       memory_output_file="${OUTPUT_DIR}/${client}_${run}_second_${size}M.txt"

--- a/scripts/erigon/docker-compose-second.yaml
+++ b/scripts/erigon/docker-compose-second.yaml
@@ -17,6 +17,7 @@ services:
     - "8545:8545"
     - "8551:8551"
     command:
+    - --datadir=/var/lib/erigon
     - --private.api.addr=0.0.0.0:9090
     - --nat=any
     - --http
@@ -26,12 +27,10 @@ services:
     - --http.corsdomain=*
     - --http.api=web3,eth,net,engine
     - --txpool.disable
-    - --chain=${NETWORK:-holesky}
     - --authrpc.addr=0.0.0.0
     - --authrpc.port=8551
     - --authrpc.vhosts=*
     - --authrpc.jwtsecret=/tmp/jwt/jwtsecret
-    - --datadir=/var/lib/erigon
     - --healthcheck
     - --metrics
     - --metrics.addr=0.0.0.0

--- a/scripts/geth/docker-compose-second.yaml
+++ b/scripts/geth/docker-compose-second.yaml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   execution:
     stop_grace_period: 30m
@@ -32,7 +31,6 @@ services:
     - --datadir=/var/lib/goethereum
     - --port=30303
     - --http.port=8545
-    - --networkid=1337
     - --ws
     - --ws.addr=0.0.0.0
     - --ws.port=8546

--- a/scripts/geth/docker-compose.yaml
+++ b/scripts/geth/docker-compose.yaml
@@ -1,6 +1,5 @@
-version: "3.9"
 services:
-  execution-sync:
+  execution-init:
     container_name: gas-execution-client-sync
     image: ${EC_IMAGE_VERSION}
     networks:
@@ -10,57 +9,14 @@ services:
     - ${EC_JWT_SECRET_PATH}:/tmp/jwt/jwtsecret
     - ${GENESIS_PATH}:/tmp/genesis/genesis.json
     entrypoint: geth --cache 4096 init --datadir=/var/lib/goethereum /tmp/genesis/genesis.json
+  # Extend the execution service from execution.yaml and add dependency
   execution:
-    stop_grace_period: 30m
-    container_name: gas-execution-client
+    extends:
+      file: docker-compose-second.yaml
+      service: execution
     depends_on:
-      execution-sync:
+      execution-init:
         condition: service_completed_successfully
-    restart: unless-stopped
-    image: ${EC_IMAGE_VERSION}
-    networks:
-    - gas
-    volumes:
-    - ${EC_DATA_DIR}:/var/lib/goethereum
-    - ${EC_JWT_SECRET_PATH}:/tmp/jwt/jwtsecret
-    ports:
-    - "30303:30303/tcp"
-    - "30303:30303/udp"
-    - "8008:8008/tcp"
-    - "8545:8545"
-    - "8551:8551"
-    expose:
-    - 8545
-    - 8546
-    - 8551
-    command:
-    - --syncmode=full
-    - --nat=none
-    - --http
-    - --http.addr=0.0.0.0
-    - --http.vhosts=*
-    - --http.corsdomain=*
-    - --http.api
-    - web3,eth,net
-    - --datadir=/var/lib/goethereum
-    - --port=30303
-    - --http.port=8545
-    - --networkid=1337
-    - --ws
-    - --ws.addr=0.0.0.0
-    - --ws.port=8546
-    - --ws.api=engine,eth,web3,net,debug
-    - --authrpc.jwtsecret=/tmp/jwt/jwtsecret
-    - --authrpc.addr=0.0.0.0
-    - --authrpc.port=8551
-    - --authrpc.vhosts=*
-    - --metrics
-    - --metrics.port=8008
-    logging:
-      driver: json-file
-      options:
-        max-size: 10m
-        max-file: "10"
 networks:
   gas:
     name: gas-network


### PR DESCRIPTION
1. skips deleting execution-data so data persists for second start
2. cleanup some flag for erigon/geth
3. reuse docker-compose for geth